### PR TITLE
Add addressFamily option to awa_clientd

### DIFF
--- a/core/src/server/lwm2m_server.c
+++ b/core/src/server/lwm2m_server.c
@@ -20,7 +20,6 @@
  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ************************************************************************************************************************/
 
-
 #include <poll.h>
 #include <stdio.h>
 #include <getopt.h>
@@ -292,7 +291,7 @@ static int ParseOptions(int argc, char ** argv, Options * options)
             {0,               0,                 0,  0 }
         };
 
-        int c = getopt_long(argc, argv, "a:c:f:p:i:m:vdl:h", longOptions, &optionIndex);
+        int c = getopt_long(argc, argv, "a:e:f:p:i:m:vdl:h", longOptions, &optionIndex);
         if (c == -1)
         {
             break;


### PR DESCRIPTION
Allow the address family to be selected from the commandline.

for example:

 to select IPv4
    ./awa_clientd --addressFamily 4

 to select IPv6
    ./awa_clientd --addressFamily 6

by default IPv4 will be used.

Signed-off-by: Chris Dewbery Christopher.Dewbery@imgtec.com
