### PR TITLE
coap: Change libcoap abstraction to use seperate AddressType

### DIFF
--- a/core/src/bootstrap/lwm2m_bootstrap.c
+++ b/core/src/bootstrap/lwm2m_bootstrap.c
@@ -191,7 +191,7 @@ void Lwm2mBootstrap_BootStrapUpdate(Lwm2mContextType * context)
         // kick start sending bootstrap with callback
         if (bootStrapQueue[i].ObjectID == 0 && bootStrapQueue[i].ObjectInstanceID == -1)
         {
-            Lwm2mBootstrap_TransactionCallback(&bootStrapQueue[i], NULL, NULL, Lwm2mResult_Success, 0, NULL, 0);
+            Lwm2mBootstrap_TransactionCallback(&bootStrapQueue[i], &bootStrapQueue[i].Addr, NULL, Lwm2mResult_Success, 0, NULL, 0);
         }
     }
 }

--- a/core/src/bootstrap/lwm2m_bootstrap_core.c
+++ b/core/src/bootstrap/lwm2m_bootstrap_core.c
@@ -134,7 +134,7 @@ static int Lwm2mCore_HandleRequest(CoapRequest * request, CoapResponse * respons
         return 0;
     }
 
-    return endPoint->Handler(request->type, request->ctxt, request->addr, request->path, request->query,
+    return endPoint->Handler(request->type, request->ctxt, &request->addr, request->path, request->query,
                              request->token, request->tokenLength, request->contentType, request->requestContent,
                              request->requestContentLen, &response->responseContentType, response->responseContent,
                              &response->responseContentLen, &response->responseCode);

--- a/core/src/client/lwm2m_client_core.c
+++ b/core/src/client/lwm2m_client_core.c
@@ -1743,7 +1743,7 @@ static int Lwm2mCore_HandleRequest(CoapRequest * request, CoapResponse * respons
         return 0;
     }
 
-    return endPoint->Handler(request->type, request->ctxt, request->addr, request->path, request->query,
+    return endPoint->Handler(request->type, request->ctxt, &request->addr, request->path, request->query,
                              request->token, request->tokenLength, request->contentType, request->requestContent,
                              request->requestContentLen, &response->responseContentType, response->responseContent,
                              &response->responseContentLen, &response->responseCode);

--- a/core/src/common/coap_abstraction.h
+++ b/core/src/common/coap_abstraction.h
@@ -41,7 +41,7 @@ typedef struct
 {
     int type;
     void * ctxt;
-    AddressType * addr;
+    AddressType addr;
     const char * path;
     const char * query;
     const char * token;

--- a/core/src/server/lwm2m_server_core.c
+++ b/core/src/server/lwm2m_server_core.c
@@ -85,7 +85,7 @@ static int Lwm2mCore_HandleRequest(CoapRequest * request, CoapResponse * respons
     ResourceEndPoint * endPoint = Lwm2mCore_FindResourceEndPoint(&context->EndPointList, request->path);
     if (endPoint != NULL)
     {
-        result = endPoint->Handler(request->type, request->ctxt, request->addr, request->path, request->query,
+        result = endPoint->Handler(request->type, request->ctxt, &request->addr, request->path, request->query,
                  request->token, request->tokenLength, request->contentType, request->requestContent,
                  request->requestContentLen, &response->responseContentType, response->responseContent,
                  &response->responseContentLen, &response->responseCode);


### PR DESCRIPTION
The AddressType overlaps has the same definition as coap_address_t so they were being used interchangeably. This may cause problems if the coap_address_t changes so this change separates the two. The transaction has also been fixed as it was using stack memory to store the address. The root of this change is due to the bootstrap server working incorrectly.
