### PR TITLE
Static API Initialisation code and tests

### DIFF
--- a/api/include/awa/static.h
+++ b/api/include/awa/static.h
@@ -59,12 +59,12 @@ typedef int (*AwaStaticClientHandler)(AwaStaticClient * client, AwaOperation ope
  ************************************************************************************************************/
 
 //Main process function
-int AwaStaticClient_Process(AwaStaticClient * core);
+int AwaStaticClient_Process(AwaStaticClient * client);
 
 //Initialisation functions
 //AwaError AwaStaticClient_SetLogLevel(AwaStaticClient * client, DebugLevel level);
-AwaError AwaStaticClient_SetEndPointName(AwaStaticClient * client, const char * EndPointName);
-AwaError AwaStaticClient_SetCOAPPort(AwaStaticClient * client, int port);
+AwaError AwaStaticClient_SetEndPointName(AwaStaticClient * client, const char * endPointName);
+AwaError AwaStaticClient_SetCOAPListenAddressPort(AwaStaticClient * client, const char * address, int port);
 AwaError AwaStaticClient_SetBootstrapServerURI(AwaStaticClient * client, const char * bootstrapServerURI);
 AwaError AwaStaticClient_SetFactorBootstrapInformation(AwaStaticClient * client, const char * factoryBootstrapInformation);
 

--- a/api/tests-static/CMakeLists.txt
+++ b/api/tests-static/CMakeLists.txt
@@ -1,7 +1,12 @@
 set (STATIC_API_TEST_DIR ${CMAKE_CURRENT_SOURCE_DIR} CACHE INTERNAL "STATIC_API_TEST_DIR")
 
 set (test_static_api_runner_SOURCES
-  support/main/main.cc
+  ../tests/support/main/main.cc
+  ../tests/support/main/main_cmdline.c
+  ../tests/support/support.cc
+  ../tests/support/process.cc
+  ../tests/support/daemon.cc
+
   test_client.cc
 )
 
@@ -18,6 +23,8 @@ set (test_static_api_runner_LIBRARIES
   gtest
   pthread
   awa_clientd_static
+  lwm2m_common_static
+  Awa_static
   libb64_static
 )
 

--- a/api/tests-static/test_client.cc
+++ b/api/tests-static/test_client.cc
@@ -1,8 +1,16 @@
 #include <gtest/gtest.h>
 #include "awa/static.h"
+#include "awa/server.h"
+#include "../tests/support/support.h"
+#include "../tests/support/daemon.h"
+
+namespace StaticClient {
+int staticClientProcessBootstrapTimeout = 10;
+
+}
 
 
-namespace AwaStatic {
+namespace Awa {
 
 class TestStaticClient : public testing::Test
 {
@@ -34,4 +42,219 @@ TEST_F(TestStaticClient, AwaStaticClient_New_Init_Unconfigured_Client)
     EXPECT_TRUE(client == NULL);
 }
 
-} // namespace AwaStatic
+TEST_F(TestStaticClient, AwaStaticClient_SetBootstrapServerURI_vaild_input)
+{
+    AwaStaticClient * client = AwaStaticClient_New();
+    EXPECT_TRUE(client != NULL);
+
+    ASSERT_EQ(AwaError_Success, AwaStaticClient_SetBootstrapServerURI(client, "coap://127.0.0.1:15683/"));
+
+    AwaStaticClient_Free(&client);
+    EXPECT_TRUE(client == NULL);
+}
+
+TEST_F(TestStaticClient, AwaStaticClient_SetBootstrapServerURI_invaild_input)
+{
+    AwaStaticClient * client = AwaStaticClient_New();
+    EXPECT_TRUE(client != NULL);
+
+    ASSERT_EQ(AwaError_StaticClientInvalid, AwaStaticClient_SetBootstrapServerURI(NULL, "coap://127.0.0.1:15683/"));
+    ASSERT_EQ(AwaError_StaticClientInvalid, AwaStaticClient_SetBootstrapServerURI(client, NULL));
+
+    AwaStaticClient_Free(&client);
+    EXPECT_TRUE(client == NULL);
+}
+
+TEST_F(TestStaticClient, AwaStaticClient_SetEndPointName_vaild_input)
+{
+    AwaStaticClient * client = AwaStaticClient_New();
+    EXPECT_TRUE(client != NULL);
+
+    ASSERT_EQ(AwaError_Success, AwaStaticClient_SetEndPointName(client, "imagination1"));
+
+    AwaStaticClient_Free(&client);
+    EXPECT_TRUE(client == NULL);
+}
+
+TEST_F(TestStaticClient, AwaStaticClient_SetEndPointName_invaild_input)
+{
+    AwaStaticClient * client = AwaStaticClient_New();
+    EXPECT_TRUE(client != NULL);
+
+    ASSERT_EQ(AwaError_StaticClientInvalid, AwaStaticClient_SetEndPointName(NULL, "test"));
+    ASSERT_EQ(AwaError_StaticClientInvalid, AwaStaticClient_SetEndPointName(client, NULL));
+
+    AwaStaticClient_Free(&client);
+    EXPECT_TRUE(client == NULL);
+}
+
+TEST_F(TestStaticClient, AwaStaticClient_SetEndPointName_long_name)
+{
+    AwaStaticClient * client = AwaStaticClient_New();
+    EXPECT_TRUE(client != NULL);
+
+    ASSERT_EQ(AwaError_OutOfMemory, AwaStaticClient_SetEndPointName(client, "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890"));
+
+    AwaStaticClient_Free(&client);
+    EXPECT_TRUE(client == NULL);
+}
+
+TEST_F(TestStaticClient, AwaStaticClient_SetCOAPListenAddressPort_vaild_input)
+{
+    AwaStaticClient * client = AwaStaticClient_New();
+    EXPECT_TRUE(client != NULL);
+
+    ASSERT_EQ(AwaError_Success, AwaStaticClient_SetCOAPListenAddressPort(client, "::", 5683));
+
+    AwaStaticClient_Free(&client);
+    EXPECT_TRUE(client == NULL);
+}
+
+TEST_F(TestStaticClient, AwaStaticClient_SetCOAPListenAddressPort_invaild_input)
+{
+    AwaStaticClient * client = AwaStaticClient_New();
+    EXPECT_TRUE(client != NULL);
+
+    ASSERT_EQ(AwaError_StaticClientInvalid, AwaStaticClient_SetCOAPListenAddressPort(NULL, "test", 5683));
+    ASSERT_EQ(AwaError_StaticClientInvalid, AwaStaticClient_SetCOAPListenAddressPort(client, NULL, 5683));
+
+    AwaStaticClient_Free(&client);
+    EXPECT_TRUE(client == NULL);
+}
+
+TEST_F(TestStaticClient, AwaStaticClient_SetCOAPListenAddressPort_long_name)
+{
+    AwaStaticClient * client = AwaStaticClient_New();
+    EXPECT_TRUE(client != NULL);
+
+    ASSERT_EQ(AwaError_OutOfMemory, AwaStaticClient_SetCOAPListenAddressPort(client, "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890", 5683));
+
+    AwaStaticClient_Free(&client);
+    EXPECT_TRUE(client == NULL);
+}
+
+
+TEST_F(TestStaticClient, AwaStaticClient_Init_not_configured)
+{
+    AwaStaticClient * client = AwaStaticClient_New();
+    EXPECT_TRUE(client != NULL);
+
+    ASSERT_EQ(AwaError_StaticClientNotConfigured, AwaStaticClient_Init(client));
+
+    AwaStaticClient_Free(&client);
+    EXPECT_TRUE(client == NULL);
+}
+
+TEST_F(TestStaticClient, AwaStaticClient_Init_valid_inputs)
+{
+    AwaStaticClient * client = AwaStaticClient_New();
+    EXPECT_TRUE(client != NULL);
+
+    EXPECT_EQ(AwaError_Success, AwaStaticClient_SetBootstrapServerURI(client, "coap://127.0.0.1:15683/"));
+    EXPECT_EQ(AwaError_Success, AwaStaticClient_SetEndPointName(client, "imagination1"));
+    EXPECT_EQ(AwaError_Success, AwaStaticClient_SetCOAPListenAddressPort(client, "0.0.0.0", 5683));
+
+    ASSERT_EQ(AwaError_Success, AwaStaticClient_Init(client));
+
+    AwaStaticClient_Free(&client);
+    EXPECT_TRUE(client == NULL);
+}
+
+TEST_F(TestStaticClient, AwaStaticClient_Process)
+{
+    AwaStaticClient * client = AwaStaticClient_New();
+    EXPECT_TRUE(client != NULL);
+
+    EXPECT_EQ(AwaError_Success, AwaStaticClient_SetBootstrapServerURI(client, "coap://127.0.0.1:15683/"));
+    EXPECT_EQ(AwaError_Success, AwaStaticClient_SetEndPointName(client, "imagination1"));
+    EXPECT_EQ(AwaError_Success, AwaStaticClient_SetCOAPListenAddressPort(client, "0.0.0.0", 5683));
+
+    EXPECT_EQ(AwaError_Success, AwaStaticClient_Init(client));
+
+    AwaStaticClient_Process(client);
+
+    AwaStaticClient_Free(&client);
+    EXPECT_TRUE(client == NULL);
+}
+
+TEST_F(TestStaticClient,  AwaStaticClient_Bootstrap_Test)
+{
+    std::string testDescription = std::string(CURRENT_TEST_CASE_NAME + std::string(".") + CURRENT_TEST_NAME);
+
+    int bootstrapServerCoapPort = 23667;
+    std::string bootstrapServerAddress = "127.0.0.1";
+    std::string bootstrapURI = std::string("coap://") + bootstrapServerAddress + std::string(":") + std::to_string(bootstrapServerCoapPort);
+    AwaBootstrapServerDaemon bootstrapServerDaemon;
+    bootstrapServerDaemon.SetCoapPort(bootstrapServerCoapPort);
+
+    std::string serverAddress = "127.0.0.1";
+    int serverCoapPort = 44443;
+    int serverIpcPort = 6301;
+    AwaServerDaemon serverDaemon;
+    serverDaemon.SetCoapPort(serverCoapPort);
+    serverDaemon.SetIpcPort(serverIpcPort);
+
+    std::string bootstrapConfigFilename = tmpnam(NULL);
+    BootstrapConfigFile bootstrapConfigFile (bootstrapConfigFilename, serverAddress, serverCoapPort);
+    bootstrapServerDaemon.SetConfigFile(bootstrapConfigFile.GetFilename());
+
+    // start the bootstrap and server daemons
+    EXPECT_TRUE(bootstrapServerDaemon.Start(testDescription));
+    EXPECT_TRUE(serverDaemon.Start(testDescription));
+
+    std::string clientEndpointName = "BootstrapTestClient";
+    AwaStaticClient * client = AwaStaticClient_New();
+    EXPECT_TRUE(client != NULL);
+
+    EXPECT_EQ(AwaError_Success, AwaStaticClient_SetBootstrapServerURI(client, bootstrapURI.c_str()));
+    EXPECT_EQ(AwaError_Success, AwaStaticClient_SetEndPointName(client, clientEndpointName.c_str()));
+    EXPECT_EQ(AwaError_Success, AwaStaticClient_SetCOAPListenAddressPort(client, "0.0.0.0", 5683));
+
+    EXPECT_EQ(AwaError_Success, AwaStaticClient_Init(client));
+
+    // wait for the client to register with the server
+    AwaServerSession * session = AwaServerSession_New();
+    EXPECT_TRUE(NULL != session);
+    EXPECT_EQ(AwaError_Success, AwaServerSession_SetIPCAsUDP(session, serverAddress.c_str(), serverIpcPort));
+    EXPECT_EQ(AwaError_Success, AwaServerSession_Connect(session));
+
+
+    AwaServerListClientsOperation * operation = AwaServerListClientsOperation_New(session);
+    EXPECT_TRUE(NULL != operation);
+
+    bool found = false;
+    int counter = 0;
+
+    while(counter < StaticClient::staticClientProcessBootstrapTimeout && !found)
+    {
+        EXPECT_EQ(AwaError_Success, AwaServerListClientsOperation_Perform(operation, defaults::timeout));
+        AwaClientIterator * iterator = AwaServerListClientsOperation_NewClientIterator(operation);
+        EXPECT_TRUE(iterator != NULL);
+        if (AwaClientIterator_Next(iterator))
+        {
+            if (clientEndpointName.compare(AwaClientIterator_GetClientID(iterator)) == 0)
+            {
+                found = true;
+                printf("Took %d iterations of AwaStaticClient_Process to bootstrap and register.\n", counter);
+            }
+        }
+        counter++;
+        AwaClientIterator_Free(&iterator);
+        AwaStaticClient_Process(client);
+    }
+
+    //Check it hasn't timed out.
+    ASSERT_NE(counter, StaticClient::staticClientProcessBootstrapTimeout);
+    ASSERT_TRUE(found);
+
+    AwaServerListClientsOperation_Free(&operation);
+    AwaServerSession_Free(&session);
+
+    AwaStaticClient_Free(&client);
+    EXPECT_TRUE(client == NULL);
+
+    serverDaemon.Stop();
+    bootstrapServerDaemon.Stop();
+}
+
+} // namespace Awa

--- a/core/src/client/lwm2m_core.h
+++ b/core/src/client/lwm2m_core.h
@@ -52,14 +52,21 @@ extern "C" {
 extern ResourceOperationHandlers defaultResourceOperationHandlers;
 extern ObjectOperationHandlers defaultObjectOperationHandlers;
 
+Lwm2mContextType * Lwm2mCore_New();
+void Lwm2mCore_SetCoapInfo(Lwm2mContextType * context, CoapInfo * coap);
+CoapInfo * Lwm2mCore_GetCoapInfo(Lwm2mContextType * context);
+
 // Initialise the LWM2M core, setup any callbacks, initialise CoAP etc
 Lwm2mContextType * Lwm2mCore_Init(CoapInfo * coap, char * endPointName);
+
+
 
 void Lwm2mCore_SetFactoryBootstrap(Lwm2mContextType * context, const BootstrapInfo * factoryBootstrapInformation);
 
 // Update the LWM2M state machine, process any message timeouts, registration attempts etc.
 int Lwm2mCore_Process(Lwm2mContextType * context);
 
+int Lwm2mCore_SetEndPointClientName(Lwm2mContextType * context, const char * endpoint);
 int Lwm2mCore_GetEndPointClientName(Lwm2mContextType * context, char * buffer, int len);
 
 void Lwm2mCore_GetObjectList(Lwm2mContextType * context, char * altPath, char * buffer, int len, bool updated);

--- a/core/src/client/lwm2m_security_object.c
+++ b/core/src/client/lwm2m_security_object.c
@@ -589,7 +589,7 @@ int Lwm2m_GetClientHoldOff(Lwm2mContextType * context, int shortServerID, int32_
     return result;
 }
 
-static void Lwm2m_PopulateSecurityObjectInstance(Lwm2mContextType * context, int instanceID, char * serverURI, int bootstrap, LWM2MSecurityMode securityMode, LWM2MSecurityInfo * securityInfo, int serverID, int holdOffTime)
+static void Lwm2m_PopulateSecurityObjectInstance(Lwm2mContextType * context, int instanceID, const char * serverURI, int bootstrap, LWM2MSecurityMode securityMode, LWM2MSecurityInfo * securityInfo, int serverID, int holdOffTime)
 {
     int securityModeAsInt = (int)securityMode;
     Lwm2mCore_CreateObjectInstance(context, LWM2M_SECURITY_OBJECT, instanceID);
@@ -607,7 +607,7 @@ static void Lwm2m_PopulateSecurityObjectInstance(Lwm2mContextType * context, int
     Lwm2mCore_SetResourceInstanceValue(context, LWM2M_SECURITY_OBJECT, instanceID, 11, 0,  &holdOffTime,                      sizeof(holdOffTime));
 }
 
-void Lwm2m_PopulateSecurityObject(Lwm2mContextType * context, char * bootStrapServer)
+void Lwm2m_PopulateSecurityObject(Lwm2mContextType * context, const char * bootStrapServer)
 {
     // Populate security object with defaults
     LWM2MSecurityInfo securityInfo;

--- a/core/src/client/lwm2m_security_object.h
+++ b/core/src/client/lwm2m_security_object.h
@@ -46,7 +46,7 @@ typedef enum
 
 
 void Lwm2m_RegisterSecurityObject(Lwm2mContextType * context);
-void Lwm2m_PopulateSecurityObject(Lwm2mContextType * context, char * bootStrapServer);
+void Lwm2m_PopulateSecurityObject(Lwm2mContextType * context, const char * bootStrapServer);
 
 int Lwm2m_GetServerURI(Lwm2mContextType * context, int shortServerID, char * buffer, int len);
 int Lwm2m_GetClientHoldOff(Lwm2mContextType * context, int shortServerID, int32_t * clientHoldOff);

--- a/core/src/client/lwm2m_static.c
+++ b/core/src/client/lwm2m_static.c
@@ -20,16 +20,51 @@
  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ************************************************************************************************************************/
 
+#include <signal.h>
+#include <errno.h>
+#include <poll.h>
+
 #include "lwm2m_static.h"
+#include "lwm2m_security_object.h"
+#include "lwm2m_server_object.h"
+#include "lwm2m_acl_object.h"
+
+#define MAX_ADDRESS_LENGTH      50
+
+struct _AwaStaticClient
+{
+    Lwm2mContextType * Context;
+    CoapInfo * COAP;
+    bool BootstrapConfigured;
+    bool EndpointNameConfigured;
+    bool COAPConfigured;
+    bool Running;
+    const char * BootstrapServerURI;
+    char COAPListenAddress[MAX_ADDRESS_LENGTH];
+    int COAPListenPort;
+};
 
 AwaStaticClient * AwaStaticClient_New()
 {
     AwaStaticClient * client = (AwaStaticClient *)malloc(sizeof(*client));
 
-    if(client != NULL)
+    if (client != NULL)
     {
         memset(client, 0, sizeof(*client));
-        client->Configured = false;
+        client->Context = Lwm2mCore_New();
+
+        if (client->Context != NULL)
+        {
+            client->BootstrapConfigured = false;
+            client->EndpointNameConfigured = false;
+            client->COAPConfigured = false;
+            client->Running = false;
+        }
+        else
+        {
+            free(client);
+            client = NULL;
+        }
     }
 
     return client;
@@ -37,24 +72,43 @@ AwaStaticClient * AwaStaticClient_New()
 
 void AwaStaticClient_Free(AwaStaticClient ** client)
 {
-    if(client != NULL && *client != NULL)
+    if ((client != NULL) && (*client != NULL))
     {
+        Lwm2mCore_Destroy((*client)->Context);
+
+        if((*client)->COAP != NULL)
+        {
+            coap_Destroy();
+        }
+
         free(*client);
         *client = NULL;
     }
 }
 
-
 AwaError AwaStaticClient_Init(AwaStaticClient * client)
 {
     AwaError result = AwaError_Unspecified;
 
-    if(client != NULL)
+    if (client != NULL)
     {
-        if(client->Configured)
+        if (client->COAPConfigured && client->BootstrapConfigured && client->EndpointNameConfigured)
         {
-            //All initialisation code for lwm2m_core and coap goes here.
-            result = AwaError_Unsupported;
+            client->COAP = coap_Init(client->COAPListenAddress, client->COAPListenPort, DebugLevel_Info);
+
+            if (client->COAP != NULL)
+            {
+                Lwm2mCore_SetCoapInfo(client->Context, client->COAP);
+                Lwm2m_RegisterACLObject(client->Context);
+                Lwm2m_RegisterServerObject(client->Context);
+                Lwm2m_RegisterSecurityObject(client->Context);
+                Lwm2m_PopulateSecurityObject(client->Context, client->BootstrapServerURI);
+                result = AwaError_Success;
+            }
+            else
+            {
+                result = AwaError_Internal;
+            }
         }
         else
         {
@@ -65,6 +119,135 @@ AwaError AwaStaticClient_Init(AwaStaticClient * client)
     {
         result = AwaError_StaticClientInvalid;
     }
+
+    return result;
+}
+
+AwaError AwaStaticClient_SetBootstrapServerURI(AwaStaticClient * client, const char * bootstrapServerURI)
+{
+    AwaError result = AwaError_Unspecified;
+
+    if ((client != NULL) && (bootstrapServerURI != NULL))
+    {
+        if (!client->Running)
+        {
+            client->BootstrapServerURI = bootstrapServerURI;
+            client->BootstrapConfigured = true;
+            result = AwaError_Success;
+        }
+        else
+        {
+            result = AwaError_OperationInvalid;
+        }
+    }
+    else
+    {
+        result = AwaError_StaticClientInvalid;
+    }
+
+    return result;
+}
+
+AwaError AwaStaticClient_SetEndPointName(AwaStaticClient * client, const char * EndPointName)
+{
+    AwaError result = AwaError_Unspecified;
+
+    if ((client != NULL) && (EndPointName != NULL))
+    {
+        if (!client->Running)
+        {
+            if (Lwm2mCore_SetEndPointClientName(client->Context, EndPointName) > 0)
+            {
+                client->EndpointNameConfigured = true;
+                result = AwaError_Success;
+            }
+            else
+            {
+                result = AwaError_OutOfMemory;
+            }
+        }
+        else
+        {
+            result = AwaError_OperationInvalid;
+        }
+    }
+    else
+    {
+        result = AwaError_StaticClientInvalid;
+    }
+
+    return result;
+}
+
+AwaError AwaStaticClient_SetCOAPListenAddressPort(AwaStaticClient * client, const char * address, int port)
+{
+    AwaError result = AwaError_Unspecified;
+
+    if ((client != NULL) && (address != NULL))
+    {
+        if (!client->Running)
+        {
+            if (strlen(address) < MAX_ADDRESS_LENGTH)
+            {
+                strcpy(client->COAPListenAddress, address);
+                client->COAPListenPort = port;
+                client->COAPConfigured = true;
+                result = AwaError_Success;
+            }
+            else
+            {
+                result = AwaError_OutOfMemory;
+            }
+        }
+        else
+        {
+            result = AwaError_OperationInvalid;
+        }
+    }
+    else
+    {
+        result = AwaError_StaticClientInvalid;
+    }
+
+    return result;
+}
+
+int AwaStaticClient_Process(AwaStaticClient * client)
+{
+    int result;
+    struct pollfd fds[1];
+    int nfds = 1;
+    int timeout;
+
+    fds[0].fd = client->COAP->fd;
+    fds[0].events = POLLIN;
+
+    timeout = Lwm2mCore_Process(client->Context);
+
+    result = poll(fds, nfds, timeout);
+    if (result < 0)
+    {
+        if (errno == EINTR)
+        {
+            result = timeout;
+        }
+        else
+        {
+            perror("poll:");
+        }
+    }
+    else if (result > 0)
+    {
+        if (fds[0].revents == POLLIN)
+        {
+            coap_HandleMessage();
+        }
+
+        result = timeout;
+    }
+
+    if (result == timeout)
+        coap_Process();
 
     return result;
 }

--- a/core/src/client/lwm2m_static.h
+++ b/core/src/client/lwm2m_static.h
@@ -29,10 +29,4 @@
 #include "awa/static.h"
 #include "lwm2m_core.h"
 
-struct _AwaStaticClient
-{
-    Lwm2mContextType * Context;
-    bool Configured;
-};
-
 #endif /* LWM2M_STATIC_H_ */


### PR DESCRIPTION
This adds the basic initialisation code for the Static API and appropriate test cases. The existing functionality in the daemons is still intact, but will be replaced in future commits.
