### PR TITLE
Make log output more consistent between daemon applications.

### DIFF
--- a/api/tests/support/process.cc
+++ b/api/tests/support/process.cc
@@ -104,7 +104,8 @@ void KillProcess(pid_t pid)
 {
     // kill LWM2M Client process
     //std::cout << "Kill pid " << pid_ << std::endl;
-    if (pid > 0) {
+    if (pid > 0)
+    {
         if (kill(pid, SIGKILL))
         {
             perror("kill failed");
@@ -116,7 +117,8 @@ void KillProcess(pid_t pid)
 void TerminateProcess(pid_t pid)
 {
     //std::cout << "Terminate pid " << pid_ << std::endl;
-    if (pid > 0) {
+    if (pid > 0)
+    {
         if (kill(pid, SIGTERM))
         {
             perror("kill failed");

--- a/api/tests/test_bootstrap.cc
+++ b/api/tests/test_bootstrap.cc
@@ -17,7 +17,7 @@ struct SingleClientWaitCondition : public WaitCondition
     AwaServerListClientsOperation * Operation;
     std::string ClientEndpointName;
 
-    SingleClientWaitCondition(AwaServerListClientsOperation * Operation, const std::string ClientEndpointName) :
+    SingleClientWaitCondition(AwaServerListClientsOperation * Operation, const std::string & ClientEndpointName) :
         Operation(Operation), ClientEndpointName(ClientEndpointName) {}
     virtual ~SingleClientWaitCondition() {}
     virtual bool Check()

--- a/core/src/bootstrap/lwm2m_bootstrap_server.c
+++ b/core/src/bootstrap/lwm2m_bootstrap_server.c
@@ -148,16 +148,16 @@ static int Bootstrap_Start(Options * options)
     {
         PrintOptions(options);
     }
-    Lwm2m_Info("LWM2M bootstrap - version %s\n", version);
-    Lwm2m_Info("LWM2M bootstrap - CoAP port %d\n", options->Port);
+    Lwm2m_Info("Awa LWM2M Bootstrap Server, version %s\n", version);
+    Lwm2m_Info("  CoAP port      : %d\n", options->Port);
 
     if (options->InterfaceName != NULL)
     {
-        Lwm2m_Info("LWM2M bootstrap - Using interface %s [IPv%d]\n", options->InterfaceName, options->AddressFamily == AF_INET? 4 : 6);
+        Lwm2m_Info("  Interface      : %s [IPv%d]\n", options->InterfaceName, options->AddressFamily == AF_INET? 4 : 6);
     }
     else if (strcmp(DEFAULT_IP_ADDRESS, options->IPAddress) != 0)
     {
-        Lwm2m_Info("LWM2M bootstrap - IP Address %s\n", options->IPAddress);
+        Lwm2m_Info("  IP Address     : %s\n", options->IPAddress);
     }
 
     char ipAddress[NI_MAXHOST];
@@ -168,7 +168,7 @@ static int Bootstrap_Start(Options * options)
             result = 1;
             goto error_close_log;
         }
-        Lwm2m_Info("LWM2M bootstrap - Interface Address %s\n", ipAddress);
+        Lwm2m_Info("  Interface Addr : %s\n", ipAddress);
     }
     else
     {

--- a/core/src/client/lwm2m_bootstrap.c
+++ b/core/src/client/lwm2m_bootstrap.c
@@ -69,7 +69,7 @@ static void Lwm2m_SendBootStrapRequest(Lwm2mContextType * context, int shortServ
     Lwm2m_GetServerURI(context, shortServerID, serverPath, sizeof(serverPath));
 
     sprintf(uri, "%s%s%s", serverPath, uriPath, uriQuery);
-    Lwm2m_Info("Bootstrap %s\n", uri);
+    Lwm2m_Info("Bootstrap with %s\n", uri);
 
     coap_PostRequest(context, uri, ContentType_None, NULL, 0, Lwm2m_HandleBootstrapResponse);
 }
@@ -80,7 +80,7 @@ static void Lwm2m_HandleBootstrapResponse(void * ctxt, AddressType* address, con
 
     if (responseCode == 204)
     {
-        Lwm2m_Info("Waiting for bootstrap finished\n");
+        Lwm2m_Info("Waiting for bootstrap to finish\n");
         Lwm2mCore_SetBootstrapState(context, Lwm2mBootStrapState_BootStrapFinishPending);
         Lwm2mCore_SetLastBootStrapUpdate(context, Lwm2mCore_GetTickCountMs());
     }
@@ -219,7 +219,7 @@ void Lwm2m_UpdateBootStrapState(Lwm2mContextType * context)
 
             if (now - Lwm2mCore_GetLastBootStrapUpdate(context) >= (clientHoldOff * 1000))
             {
-                Lwm2m_Info("HoldOff Expired - Attempt Client Bootstrap\n");
+                Lwm2m_Info("Hold Off expired - attempt client-initiated bootstrap\n");
                 Lwm2mCore_SetBootstrapState(context, Lwm2mBootStrapState_BootStrapPending);
                 Lwm2m_SendBootStrapRequest(context, SERVER_BOOTSTRAP);
                 Lwm2mCore_SetLastBootStrapUpdate(context, now);

--- a/core/src/client/lwm2m_client.c
+++ b/core/src/client/lwm2m_client.c
@@ -176,10 +176,11 @@ static int Lwm2mClient_Start(Options * options)
     {
         PrintOptions(options);
     }
-    Lwm2m_Info("LWM2M client - version %s\n", version);
-    Lwm2m_Info("LWM2M client - Local CoAP port %d\n", options->CoapPort);
-    Lwm2m_Info("LWM2M client - Local IPC port %d\n", options->IpcPort);
-    Lwm2m_Info("LWM2M client - Using IPv%d\n", options->AddressFamily == AF_INET ? 4 : 6);
+    Lwm2m_Info("Awa LWM2M Client, version %s\n", version);
+    Lwm2m_Info("  Endpoint name  : \'%s\'\n", options->EndPointName);
+    Lwm2m_Info("  CoAP port      : %d\n", options->CoapPort);
+    Lwm2m_Info("  IPC port       : %d\n", options->IpcPort);
+    Lwm2m_Info("  Address family : IPv%d\n", options->AddressFamily == AF_INET ? 4 : 6);
 
     CoapInfo * coap = coap_Init((options->AddressFamily == AF_INET) ? "0.0.0.0" : "::", options->CoapPort, (options->Verbose) ? DebugLevel_Debug : DebugLevel_Info);
     if (coap == NULL)
@@ -195,9 +196,17 @@ static int Lwm2mClient_Start(Options * options)
     {
         factoryBootstrapInfo = BootstrapInformation_ReadConfigFile(options->FactoryBootstrapFile);
         if (factoryBootstrapInfo == NULL)
-        { 
+        {
+            Lwm2m_Error("Factory Bootstrap configuration file load failed\n");
             result = 1;
             goto error_coap;
+        }
+        else
+        {
+            Lwm2m_Info("Factory Bootstrap:\n");
+            Lwm2m_Info("Server Configuration\n");
+            Lwm2m_Info("====================\n");
+            BootstrapInformation_Dump(factoryBootstrapInfo);
         }
     }
     else

--- a/core/src/client/lwm2m_registration.c
+++ b/core/src/client/lwm2m_registration.c
@@ -134,8 +134,9 @@ static void Lwm2m_SendRegisterRequest(Lwm2mContextType * context, Lwm2mServerTyp
 
     Lwm2m_Debug("Registration: POST %s %s %s %s\n", serverUri, uriPath, uriQuery, payload);
 
+    Lwm2m_Info("Register with %s\n", serverUri);
     sprintf(uri, "%s%s%s", serverUri, uriPath, uriQuery);
-    Lwm2m_Info("Registration %s\n", uri);
+    Lwm2m_Debug("Register: POST %s\n", uri);
 
     coap_PostRequest(server, uri, ContentType_ApplicationLinkFormat, payload, strlen(payload), Lwm2m_HandleRegisterResponse);
     server->RegistrationState = Lwm2mRegistrationState_Registering;
@@ -148,7 +149,7 @@ static void Lwm2m_HandleRegisterResponse(void * ctxt, AddressType* address, cons
     if (responseCode == 201)
     {
         Lwm2m_Debug("Registration Response %s %d\n", responsePath, responseCode);
-        Lwm2m_Info("Registration Success\n");
+        Lwm2m_Info("Registered\n");
         strcpy(server->Location, responsePath);
         server->RegistrationState = Lwm2mRegistrationState_Registered;
     }
@@ -233,8 +234,9 @@ static void Lwm2m_Deregister(Lwm2mContextType * context, Lwm2mServerType * serve
     }
 
     Lwm2m_GetServerURI(context, server->ShortServerID, serverUri, sizeof(serverUri));
+    Lwm2m_Info("Deregister from %s\n", serverUri);
     sprintf(uri, "%s%s", serverUri, server->Location);
-    Lwm2m_Info("Deregister: DELETE %s\n", uri);
+    Lwm2m_Debug("Deregister: DELETE %s\n", uri);
     coap_DeleteRequest(server, uri, Lwm2m_HandleDeregisterResponse);
     server->RegistrationState = Lwm2mRegistrationState_Deregistering;
 }
@@ -242,13 +244,12 @@ static void Lwm2m_Deregister(Lwm2mContextType * context, Lwm2mServerType * serve
 static void Lwm2m_HandleDeregisterResponse(void * ctxt, AddressType* address, const char * responsePath, int responseCode, ContentType contentType, char * payload, int payloadLen)
 {
     Lwm2mServerType * server = ctxt;
-
     if (responseCode == 202)
     {
         server->RegistrationState = Lwm2mRegistrationState_NotRegistered;
+        Lwm2m_Info("Deregistered\n");
     }
 }
-
 
 // Set all servers to send a Registration Update.
 void Lwm2m_SetUpdateRegistration(Lwm2mContextType * context)

--- a/core/src/common/lwm2m_bootstrap_config.c
+++ b/core/src/common/lwm2m_bootstrap_config.c
@@ -212,18 +212,18 @@ const BootstrapInfo * BootstrapInformation_ReadConfigFile(const char * configFil
 
 void BootstrapInformation_Dump(const BootstrapInfo * bootstrapInfo)
 {
-    Lwm2m_Info("ServerURI     : %s\n", bootstrapInfo->SecurityInfo.ServerURI);
-    Lwm2m_Info("SecurityMode  : %d\n", bootstrapInfo->SecurityInfo.SecurityMode);
-    Lwm2m_Info("SecretKey     : %s\n", bootstrapInfo->SecurityInfo.SecretKey);
-    Lwm2m_Info("PublicKey     : %s\n", bootstrapInfo->SecurityInfo.PublicKey);
-    Lwm2m_Info("ServerID      : %d\n", bootstrapInfo->SecurityInfo.ServerID);
-    Lwm2m_Info("HoldOffTime   : %d\n", bootstrapInfo->SecurityInfo.HoldOffTime);
-    Lwm2m_Info("ShortServerID : %d\n", bootstrapInfo->ServerInfo.ShortServerID);
-    Lwm2m_Info("Binding       : %s\n", bootstrapInfo->ServerInfo.Binding);
-    Lwm2m_Info("LifeTime      : %d\n", bootstrapInfo->ServerInfo.LifeTime);
+    Lwm2m_Info("ServerURI            : %s\n", bootstrapInfo->SecurityInfo.ServerURI);
+    Lwm2m_Info("SecurityMode         : %d\n", bootstrapInfo->SecurityInfo.SecurityMode);
+    Lwm2m_Info("SecretKey            : %s\n", bootstrapInfo->SecurityInfo.SecretKey);
+    Lwm2m_Info("PublicKey            : %s\n", bootstrapInfo->SecurityInfo.PublicKey);
+    Lwm2m_Info("ServerID             : %d\n", bootstrapInfo->SecurityInfo.ServerID);
+    Lwm2m_Info("HoldOffTime          : %d\n", bootstrapInfo->SecurityInfo.HoldOffTime);
+    Lwm2m_Info("ShortServerID        : %d\n", bootstrapInfo->ServerInfo.ShortServerID);
+    Lwm2m_Info("Binding              : %s\n", bootstrapInfo->ServerInfo.Binding);
+    Lwm2m_Info("LifeTime             : %d\n", bootstrapInfo->ServerInfo.LifeTime);
+    Lwm2m_Info("DisableTimeout       : %d\n", bootstrapInfo->ServerInfo.DisableTimeout);
     Lwm2m_Info("DefaultMinimumPeriod : %d\n", bootstrapInfo->ServerInfo.MinPeriod);
     Lwm2m_Info("DefaultMaximumPeriod : %d\n", bootstrapInfo->ServerInfo.MaxPeriod);
-    Lwm2m_Info("DisableTimeout : %d\n", bootstrapInfo->ServerInfo.DisableTimeout);
     Lwm2m_Info("NotificationStoringWhenDisabledOrOffline : %d\n", bootstrapInfo->ServerInfo.Notification);
 }
 

--- a/core/src/common/lwm2m_debug.h
+++ b/core/src/common/lwm2m_debug.h
@@ -43,11 +43,7 @@ typedef enum {
     DebugLevel_Debug
 } DebugLevel;
 
-#define DEBUG_FILELINE
 #define DEBUG_FANCY
-
-#define xstringy(a) stringy(a)
-#define stringy(a) #a
 
 // Host dependent directory slash
 #define DIR_SLASH '/'
@@ -56,55 +52,63 @@ typedef enum {
 #  define __attribute__(X)
 #endif // __GNUC__
 
-void Lwm2m_Printf(DebugLevel level, char const * format, ...) __attribute__ ((format (printf, 2, 3)));
+void Lwm2m_Printf(DebugLevel level, char const * format, ...) __attribute__ ((format (printf, 2, 3)));;
+void Lwm2m_vPrintf(DebugLevel level, char const * format, va_list argp);
+
+void Lwm2m_Log(DebugLevel level, const char * fileName, int lineNum, char const * format, ...) __attribute__ ((format (printf, 4, 5)));
 
 #ifdef DEBUG_FANCY
-#define ANSI_COLOUR_RED     "\x1b[31m"
-#define ANSI_COLOUR_GREEN   "\x1b[32m"
-#define ANSI_COLOUR_YELLOW  "\x1b[33m"
-#define ANSI_COLOUR_BLUE    "\x1b[34m"
-#define ANSI_COLOUR_MAGENTA "\x1b[35m"
-#define ANSI_COLOUR_CYAN    "\x1b[36m"
-#define ANSI_COLOUR_RESET   "\x1b[0m"
+#  define ANSI_COLOUR_RED            "\x1b[31m"
+#  define ANSI_COLOUR_GREEN          "\x1b[32m"
+#  define ANSI_COLOUR_YELLOW         "\x1b[33m"
+#  define ANSI_COLOUR_BLUE           "\x1b[34m"
+#  define ANSI_COLOUR_MAGENTA        "\x1b[35m"
+#  define ANSI_COLOUR_CYAN           "\x1b[36m"
+#  define ANSI_COLOUR_WHITE          "\x1b[37m"
+#  define ANSI_COLOUR_BRIGHT_RED     "\x1b[31;01m"
+#  define ANSI_COLOUR_BRIGHT_GREEN   "\x1b[32;01m"
+#  define ANSI_COLOUR_BRIGHT_YELLOW  "\x1b[33;01m"
+#  define ANSI_COLOUR_BRIGHT_BLUE    "\x1b[34;01m"
+#  define ANSI_COLOUR_BRIGHT_MAGENTA "\x1b[35;01m"
+#  define ANSI_COLOUR_BRIGHT_CYAN    "\x1b[36;01m"
+#  define ANSI_COLOUR_BRIGHT_WHITE   "\x1b[37;01m"
+#  define ANSI_COLOUR_RESET          "\x1b[0;00m"
 #else
-#define ANSI_COLOUR_RED
-#define ANSI_COLOUR_GREEN
-#define ANSI_COLOUR_YELLOW
-#define ANSI_COLOUR_BLUE
-#define ANSI_COLOUR_MAGENTA
-#define ANSI_COLOUR_CYAN
-#define ANSI_COLOUR_RESET
+#  define ANSI_COLOUR_RED
+#  define ANSI_COLOUR_GREEN
+#  define ANSI_COLOUR_YELLOW
+#  define ANSI_COLOUR_BLUE
+#  define ANSI_COLOUR_MAGENTA
+#  define ANSI_COLOUR_CYAN
+#  define ANSI_COLOUR_WHITE
+#  define ANSI_COLOUR_BRIGHT_RED
+#  define ANSI_COLOUR_BRIGHT_GREEN
+#  define ANSI_COLOUR_BRIGHT_YELLOW
+#  define ANSI_COLOUR_BRIGHT_BLUE
+#  define ANSI_COLOUR_BRIGHT_MAGENTA
+#  define ANSI_COLOUR_BRIGHT_CYAN
+#  define ANSI_COLOUR_BRIGHT_WHITE
+#  define ANSI_COLOUR_RESET
 #endif
-
-#ifdef DEBUG_FILELINE
 
 void Lwm2m_PrintBanner(void);
 
-#define _Lwm2m_Printf(COLOUR, level, format, ...) \
-{\
-    const char * fileName = __FILE__;\
-    const char * lineNum = xstringy(__LINE__);\
-    const char * shortFileName = strrchr(fileName, DIR_SLASH);\
-    Lwm2m_Printf(level, ANSI_COLOUR_YELLOW "[%s:%s] " COLOUR format ANSI_COLOUR_RESET, shortFileName ? shortFileName+1 : fileName, lineNum, ##__VA_ARGS__);\
-}\
-
-#else
-
-#define _Lwm2m_Printf(level, format, ...) \
-        Lwm2m_Printf(, level, format, ##__VA_ARGS__)
-#endif
+#define _Lwm2m_Log(COLOUR, level, format, ...) \
+{ \
+    Lwm2m_Log(level, __FILE__, __LINE__, COLOUR format ANSI_COLOUR_RESET, ##__VA_ARGS__); \
+}
 
 #define Lwm2m_Debug(format, ...) \
-    _Lwm2m_Printf(ANSI_COLOUR_RESET, DebugLevel_Debug, format, ##__VA_ARGS__)
+    _Lwm2m_Log(ANSI_COLOUR_RESET, DebugLevel_Debug, format, ##__VA_ARGS__)
 
 #define Lwm2m_Error(format, ...) \
-    _Lwm2m_Printf(ANSI_COLOUR_RED, DebugLevel_Error, format, ##__VA_ARGS__)
+    _Lwm2m_Log(ANSI_COLOUR_BRIGHT_RED, DebugLevel_Error, format, ##__VA_ARGS__)
 
 #define Lwm2m_Warning(format, ...) \
-    _Lwm2m_Printf(ANSI_COLOUR_YELLOW, DebugLevel_Warning, format, ##__VA_ARGS__)
+    _Lwm2m_Log(ANSI_COLOUR_BRIGHT_YELLOW, DebugLevel_Warning, format, ##__VA_ARGS__)
 
 #define Lwm2m_Info(format, ...) \
-    _Lwm2m_Printf(ANSI_COLOUR_CYAN, DebugLevel_Info, format, ##__VA_ARGS__)
+    _Lwm2m_Log(ANSI_COLOUR_CYAN, DebugLevel_Info, format, ##__VA_ARGS__)
 
 void Lwm2m_SetOutput(FILE * output);
 

--- a/core/src/server/lwm2m_registration.c
+++ b/core/src/server/lwm2m_registration.c
@@ -315,7 +315,7 @@ static int Lwm2m_RegisterClient(Lwm2mContextType * context, const char * endPoin
     Lwm2mClientType * client = Lwm2m_LookupClientByName(context, endPointName);
     if (client == NULL)
     {
-        Lwm2m_Info("Register new client %s\n", endPointName);
+        Lwm2m_Info("Client registered: \'%s\'\n", endPointName);
 
         client = malloc(sizeof(Lwm2mClientType));
         if (client != NULL)
@@ -360,6 +360,8 @@ static void Lwm2m_DeregisterClient(Lwm2mContextType * context, Lwm2mClientType *
     sprintf(RegisterLocation, "/rd/%d", client->Location);
     Lwm2mCore_RemoveResourceEndPoint(context, RegisterLocation);
 
+    Lwm2m_Info("Client deregistered: \'%s\'\n", client->EndPointName);
+
     free(client->EndPointName);
     free(client);
 }
@@ -403,7 +405,7 @@ static int Lwm2m_RegisterPost(void * ctxt, AddressType * addr, const char * path
         // Check to see if this is a re-register from the same address, otherwise treat as a duplicate.
         if ((addr->Size == client->Address.Size) && (memcmp(addr, &client->Address, addr->Size) == 0))
         {
-            Lwm2m_Info("Client %s already registered, deleting\n", q.EndPointName);
+            Lwm2m_Info("Client \'%s\' already registered, deleting\n", q.EndPointName);
             Lwm2m_DeregisterClient(context, client);
         }
     }
@@ -535,7 +537,7 @@ static int Lwm2mCore_RegistrationEndpointHandler(int type, void * ctxt, AddressT
                                                  int tokenLength, ContentType contentType, const char * requestContent, int requestContentLen,
                                                  ContentType * responseContentType, char * responseContent, int * responseContentLen, int * responseCode)
 {
-    switch(type)
+    switch (type)
     {
         case COAP_POST_REQUEST:
             return Lwm2m_RegisterPost(ctxt, addr, path, query, contentType, requestContent, requestContentLen, responseContent, responseContentLen, responseCode);
@@ -560,7 +562,7 @@ int32_t Lwm2m_AgeRegistrations(Lwm2mContextType * context)
 
         if ((now - client->LastUpdateTime) > (client->LifeTime * 1000))
         {
-            Lwm2m_Error("Client %s Lifetime Expired\n", client->EndPointName);
+            Lwm2m_Error("Client \'%s\' Lifetime Expired\n", client->EndPointName);
 
             Lwm2m_DeregisterClient(context, client);
         }
@@ -570,7 +572,7 @@ int32_t Lwm2m_AgeRegistrations(Lwm2mContextType * context)
 
 int Lwm2m_RegistrationInit(Lwm2mContextType * context)
 {
-    // Initalise client list
+    // Initialise client list
     ListInit(Lwm2mCore_GetClientList(context));
     Lwm2mCore_SetLastLocation(context, 0);
 

--- a/core/src/server/lwm2m_server.c
+++ b/core/src/server/lwm2m_server.c
@@ -152,9 +152,10 @@ static int Lwm2mServer_Start(Options * options)
     {
         PrintOptions(options);
     }
-    Lwm2m_Info("LWM2M server - version %s\n", version);
-    Lwm2m_Info("LWM2M server - CoAP port %d\n", options->CoapPort);
-    Lwm2m_Info("LWM2M server - IPC port %d\n", options->IpcPort);
+    Lwm2m_Info("Awa LWM2M Server, version %s\n", version);
+    Lwm2m_Info("  CoAP port      : %d\n", options->CoapPort);
+    Lwm2m_Info("  IPC port       : %d\n", options->IpcPort);
+    Lwm2m_Info("  Address family : IPv%d\n", options->AddressFamily == AF_INET ? 4 : 6);
 
     if (options->InterfaceName != NULL)
     {

--- a/core/tests/CMakeLists.txt
+++ b/core/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 set (test_core_runner_SOURCES
   main.cc
-  
+
   test_lwm2m_core.cc
   test_object_store_interface.cc
   test_template.cc
@@ -10,7 +10,7 @@ set (test_core_runner_SOURCES
   test_plaintext.cc
   test_prettyprint.cc
   test_lwm2m_types.cc
-  
+
   test_lwm2m_tree.cc
   test_lwm2m_tree_builder.cc
   unit_support.cc


### PR DESCRIPTION
This patch modifies the way each LWM2M daemon writes output to the console or file log. In normal mode, filename and line numbers are not output, but are still visible when the --verbose flag is used. The Imagination Technologies "logotype" has been replaced.

Ref: none
Signed-off-by: David Antliff david.antliff@imgtec.com
