### PR TITLE
Add Process ID of each daemon to log.

### DIFF
--- a/core/src/bootstrap/lwm2m_bootstrap_server.c
+++ b/core/src/bootstrap/lwm2m_bootstrap_server.c
@@ -149,6 +149,7 @@ static int Bootstrap_Start(Options * options)
         PrintOptions(options);
     }
     Lwm2m_Info("Awa LWM2M Bootstrap Server, version %s\n", version);
+    Lwm2m_Info("  Process ID     : %d\n", getpid());
     Lwm2m_Info("  CoAP port      : %d\n", options->Port);
 
     if (options->InterfaceName != NULL)

--- a/core/src/client/lwm2m_client.c
+++ b/core/src/client/lwm2m_client.c
@@ -177,6 +177,7 @@ static int Lwm2mClient_Start(Options * options)
         PrintOptions(options);
     }
     Lwm2m_Info("Awa LWM2M Client, version %s\n", version);
+    Lwm2m_Info("  Process ID     : %d\n", getpid());
     Lwm2m_Info("  Endpoint name  : \'%s\'\n", options->EndPointName);
     Lwm2m_Info("  CoAP port      : %d\n", options->CoapPort);
     Lwm2m_Info("  IPC port       : %d\n", options->IpcPort);

--- a/core/src/server/lwm2m_server.c
+++ b/core/src/server/lwm2m_server.c
@@ -153,6 +153,7 @@ static int Lwm2mServer_Start(Options * options)
         PrintOptions(options);
     }
     Lwm2m_Info("Awa LWM2M Server, version %s\n", version);
+    Lwm2m_Info("  Process ID     : %d\n", getpid());
     Lwm2m_Info("  CoAP port      : %d\n", options->CoapPort);
     Lwm2m_Info("  IPC port       : %d\n", options->IpcPort);
     Lwm2m_Info("  Address family : IPv%d\n", options->AddressFamily == AF_INET ? 4 : 6);


### PR DESCRIPTION
If a test fails within the CI test suite, it is difficult to correlate the test that failed with a particular instance of a daemon's log. Although PIDs are available in daemon.log, each daemon's log is a large concatenated collection of invocations. This patch adds a Process ID to each log to help identify specific log instances.

Ref: N/A
Signed-off-by: David Antliff david.antliff@imgtec.com
